### PR TITLE
chore: protoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,8 @@ jobs:
       - name: Install cargo-lambda
         run: pip install cargo-lambda
 
-      - name: Install protobuf-compiler
-        run: sudo apt-get install -y protobuf-compiler
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
 
       - name: Build
         run: cargo lambda build
@@ -100,8 +100,8 @@ jobs:
       - name: Install Stable Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - name: Install protobuf-compiler
-        run: sudo apt-get install -y protobuf-compiler
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
 
       - name: Run Cargo Test
         run: cargo llvm-cov --all-features --lcov --output-path lcov.info
@@ -132,8 +132,8 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - name: Install protobuf-compiler
-        run: sudo apt-get install -y protobuf-compiler
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
 
       - name: Build Project
         run: cargo build


### PR DESCRIPTION
test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the CI workflow to use `arduino/setup-protoc@v3` for installing Protoc, enhancing the build and test steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->